### PR TITLE
Change nearby attractions logic

### DIFF
--- a/Api/Services/TourGuideService.cs
+++ b/Api/Services/TourGuideService.cs
@@ -92,16 +92,17 @@ public class TourGuideService : ITourGuideService
 
     public List<Attraction> GetNearByAttractions(VisitedLocation visitedLocation)
     {
-        List<Attraction> nearbyAttractions = new ();
-        foreach (var attraction in _gpsUtil.GetAttractions())
-        {
-            if (_rewardsService.IsWithinAttractionProximity(attraction, visitedLocation.Location))
+        var attractions = _gpsUtil.GetAttractions();
+        return attractions
+            .Select(attraction => new
             {
-                nearbyAttractions.Add(attraction);
-            }
-        }
-
-        return nearbyAttractions;
+                Attraction = attraction,
+                Distance = _rewardsService.GetDistance(visitedLocation.Location, attraction)
+            })
+            .OrderBy(x => x.Distance)
+            .Take(5)
+            .Select(x => x.Attraction)
+            .ToList();
     }
 
     private void AddShutDownHook()

--- a/TourGuideTest/TourGuideServiceTest.cs
+++ b/TourGuideTest/TourGuideServiceTest.cs
@@ -85,7 +85,7 @@ namespace TourGuideTest
             Assert.Equal(user.UserId, visitedLocation.UserId);
         }
 
-        [Fact(Skip = "Not yet implemented")]
+        [Fact]
         public void GetNearbyAttractions()
         {
             _fixture.Initialize(0);


### PR DESCRIPTION
`TourGuideService.GetNearByAttractions(VisitedLocation)` now returns the 5 nearest attractions to the passed VisitedLocation, let them be farther than `RewardsService._attractionProximityRange` (200 miles).